### PR TITLE
fixed a typo?

### DIFF
--- a/regression.py
+++ b/regression.py
@@ -40,7 +40,7 @@ XT = transpose(X)
 Y = transpose([y])
 
 #solve for b (y = b0 + b1*x + b2*x^2 + b3*x^3 + ... )
-b = np.dot(np.dot(inv(np.dot(XT,X)),XT),y) 
+b = np.dot(np.dot(inv(np.dot(XT,X)),XT),Y) 
 
 ##########################################################################################
 #-------Create 100 x and y values for the regression curve, so that we can display it ----


### PR DESCRIPTION
I changed the small y to a big Y - it seems like an oversight.

Otherwise it seems like the line:
```
Y = transpose([y])
```

has no purpose.

Although, once fixing this 'typo' it seems to work either way.